### PR TITLE
Generalized URL testing, added path testing, PEP8+PyLint checks

### DIFF
--- a/missing_gettext.py
+++ b/missing_gettext.py
@@ -112,7 +112,7 @@ def _is_url(s):
                 break
 
         if not result:
-            for extension in extension:
+            for extension in extensions:
                 if strictly_ends_with(s, '.' + extension):
                     result = True
                     break


### PR DESCRIPTION
The new way to test if a text is an URL rely on `urllib`. As it's available since only Python 3.3, a fall‑back is used whenever this import fails.

The newly added test for path is not reliable in any formal sense. It's only suitable to the purpose of `python-pylint-i18n`: better too much false negative (text which are paths and not recognized as such) than false positive (text which should be translatable and erroneously recognized as file‑name or path).

PEP8 conformance is OK, but PyLint checks are the one made with my own configuration (PEP8 is fixed, PyLint checks are not) and not everything pass the PyLint checks.

TODO: this should at least pass `python-pylint-i18n` checks :-p (actually, it does not at all).
